### PR TITLE
Simplify code slightly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,1 @@
-
-const symmetricRound = (x) => Math.round(Math.abs(x)) * Math.sign(x);
-
-module.exports = {
-    symmetricRound,
-    default: symmetricRound
-};
+module.exports = (x) => Math.round(Math.abs(x)) * Math.sign(x);

--- a/index.test.js
+++ b/index.test.js
@@ -1,9 +1,13 @@
 
-const symmetricRound = require('./index.js').default;
-
-expect(symmetricRound).toBeDefined();
+const symmetricRound = require('./index.js');
 
 describe('symmetricRound() is nice because it does', () => {
+
+    test('enable import with require()', () => {
+        expect(symmetricRound).toBeDefined();
+        expect(symmetricRound).toBeInstanceOf(Function);
+        // TODO: Should test ES6 "import xxx from yyy"!?
+    });
 
     test('round numbers symmetrically', () => {
         expect(symmetricRound(0.5)).toBe(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symmetric-round",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A tiny utility function to perform symmetric rounding (a.k.a. \"commercial rounding\") on a number.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Named export isn't necessary, the default export is quite enough. This should also work with ES6 import nicely - though that hasn't been tested yet at this point (need to figure out how Jest handles those ... if at all)